### PR TITLE
feat:dnd 구현

### DIFF
--- a/src/components/taskList/AddTask.tsx
+++ b/src/components/taskList/AddTask.tsx
@@ -1,19 +1,20 @@
 import styled from 'styled-components';
 import { AiOutlinePlus } from 'react-icons/ai';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 const AddTask = ({ status, textContent }: { status: string; textContent: string }) => {
+  const navigate = useNavigate();
   return (
     <Link to={`/?mode=add&state=${status}`}>
-      <AddBtn>
+      <AddTaskBtn>
         <AiOutlinePlus size="16px" />
         <span>{textContent}</span>
-      </AddBtn>
+      </AddTaskBtn>
     </Link>
   );
 };
 
-const AddBtn = styled.button`
+const AddTaskBtn = styled.button`
   border-radius: 3px;
   padding: 12px;
   width: calc(100% - 8px);
@@ -24,6 +25,7 @@ const AddBtn = styled.button`
   align-items: center;
   gap: 10px;
   font-weight: 700;
+  cursor: pointer;
   :hover,
   :active {
     background-color: rgba(0, 0, 0, 0.1);

--- a/src/components/taskList/AddTask.tsx
+++ b/src/components/taskList/AddTask.tsx
@@ -1,18 +1,25 @@
 import styled from 'styled-components';
 import { AiOutlinePlus } from 'react-icons/ai';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 const AddTask = ({ status, textContent }: { status: string; textContent: string }) => {
-  const navigate = useNavigate();
   return (
-    <Link to={`/?mode=add&state=${status}`}>
+    <StyledLink to={`/?mode=add&state=${status}`}>
       <AddTaskBtn>
         <AiOutlinePlus size="16px" />
         <span>{textContent}</span>
       </AddTaskBtn>
-    </Link>
+    </StyledLink>
   );
 };
+
+const StyledLink = styled(Link)`
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+`;
 
 const AddTaskBtn = styled.button`
   border-radius: 3px;

--- a/src/components/taskList/TaskItem.tsx
+++ b/src/components/taskList/TaskItem.tsx
@@ -19,31 +19,26 @@ const TaskItem = ({
   const [dndDrop, setDndDrop] = useRecoilState(dndSelector('drop'));
   const reset = useResetRecoilState(dndAtom);
   const dropId = dndDrop.id === '' ? '-1' : dndDrop.id;
-  const onDragStart = (e: DragEvent) => {
+  const onDragStart = () => {
     setDndDrag({ id, state });
   };
-  const onDragEnd = (e: DragEvent) => {
+  const onDragEnd = () => {
     if (dndDrag.id === id) {
-      reset();
+      setDndDrop({ ...dndDrag });
     }
   };
-  const onDragEnter = (e: DragEvent) => {
-    e.preventDefault();
+  const onDragEnter = () => {
     if (dndDrag.id !== id) {
       setDndDrop({ id, state });
+    } else {
+      setDndDrop({ ...dndDrag });
     }
   };
   return (
     <>
-      {dropId === id && dndDrag.id !== dndDrop.id && <EmptySpace />}
+      {dndDrop.id === id && dndDrag.id !== dndDrop.id && <EmptySpace />}
       <Link to={`/?mode=edit&state=${state}&id=${id}`}>
-        <TaskLi
-          draggable
-          onDragStart={onDragStart}
-          onDragEnd={onDragEnd}
-          onDragEnter={onDragEnter}
-          isActive={dropId === id}
-        >
+        <TaskLi draggable onDragStart={onDragStart} onDragEnd={onDragEnd} onDragEnter={onDragEnter}>
           <span>{title}</span>
           {manager && <CircleIcon>{manager.slice(0, 1)}</CircleIcon>}
         </TaskLi>
@@ -51,7 +46,7 @@ const TaskItem = ({
     </>
   );
 };
-const TaskLi = styled.li<{ isActive: boolean }>`
+const TaskLi = styled.li`
   border-radius: 8px;
   padding: 12px;
   margin: 12px 4px;

--- a/src/components/taskList/TaskItem.tsx
+++ b/src/components/taskList/TaskItem.tsx
@@ -1,8 +1,8 @@
 import { DragEvent } from 'react';
 import { Link } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useResetRecoilState } from 'recoil';
 import styled from 'styled-components';
-import { dndSelector } from '../../store';
+import { dndAtom, dndSelector } from '../../store';
 
 const TaskItem = ({
   title,
@@ -17,18 +17,33 @@ const TaskItem = ({
 }) => {
   const [dndDrag, setDndDrag] = useRecoilState(dndSelector('drag'));
   const [dndDrop, setDndDrop] = useRecoilState(dndSelector('drop'));
+  const reset = useResetRecoilState(dndAtom);
   const dropId = dndDrop.id === '' ? '-1' : dndDrop.id;
   const onDragStart = (e: DragEvent) => {
     setDndDrag({ id, state });
   };
-  const onDragEnd = () => {
-    setDndDrop({ id, state });
+  const onDragEnd = (e: DragEvent) => {
+    if (dndDrag.id === id) {
+      reset();
+    }
+  };
+  const onDragEnter = (e: DragEvent) => {
+    e.preventDefault();
+    if (dndDrag.id !== id) {
+      setDndDrop({ id, state });
+    }
   };
   return (
     <>
       {dropId === id && dndDrag.id !== dndDrop.id && <EmptySpace />}
       <Link to={`/?mode=edit&state=${state}&id=${id}`}>
-        <TaskLi draggable onDragStart={onDragStart} onDragEnter={onDragEnd} isActive={dropId === id}>
+        <TaskLi
+          draggable
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onDragEnter={onDragEnter}
+          isActive={dropId === id}
+        >
           <span>{title}</span>
           {manager && <CircleIcon>{manager.slice(0, 1)}</CircleIcon>}
         </TaskLi>

--- a/src/components/taskList/TaskItem.tsx
+++ b/src/components/taskList/TaskItem.tsx
@@ -18,7 +18,8 @@ const TaskItem = ({
   const [dndDrag, setDndDrag] = useRecoilState(dndSelector('drag'));
   const [dndDrop, setDndDrop] = useRecoilState(dndSelector('drop'));
   const dropId = dndDrop.id === '' ? '-1' : dndDrop.id;
-  const onDragStart = () => {
+  const onDragStart = (e: DragEvent) => {
+    console.log(e.target);
     setDndDrag({ id, state });
   };
   const onDragEnd = () => {
@@ -26,7 +27,7 @@ const TaskItem = ({
   };
   return (
     <>
-      {dropId === id && dndDrag.id && dndDrag.id !== dndDrop.id && <EmptySpace />}
+      {dropId === id && dndDrag.id !== dndDrop.id && <EmptySpace />}
       <Link to={`/?mode=edit&state=${state}&id=${id}`}>
         <TaskLi draggable onDragStart={onDragStart} onDragEnter={onDragEnd} isActive={dropId === id}>
           <span>{title}</span>

--- a/src/components/taskList/TaskItem.tsx
+++ b/src/components/taskList/TaskItem.tsx
@@ -19,7 +19,6 @@ const TaskItem = ({
   const [dndDrop, setDndDrop] = useRecoilState(dndSelector('drop'));
   const dropId = dndDrop.id === '' ? '-1' : dndDrop.id;
   const onDragStart = (e: DragEvent) => {
-    console.log(e.target);
     setDndDrag({ id, state });
   };
   const onDragEnd = () => {

--- a/src/components/taskList/TaskItem.tsx
+++ b/src/components/taskList/TaskItem.tsx
@@ -1,5 +1,8 @@
+import { DragEvent } from 'react';
 import { Link } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
+import { dndSelector } from '../../store';
 
 const TaskItem = ({
   title,
@@ -12,25 +15,44 @@ const TaskItem = ({
   id: string;
   state: string;
 }) => {
+  const [dndDrag, setDndDrag] = useRecoilState(dndSelector('drag'));
+  const [dndDrop, setDndDrop] = useRecoilState(dndSelector('drop'));
+  const dropId = dndDrop.id === '' ? '-1' : dndDrop.id;
+  const onDragStart = () => {
+    setDndDrag({ id, state });
+  };
+  const onDragEnd = () => {
+    setDndDrop({ id, state });
+  };
   return (
-    <Link to={`/?mode=edit&state=${state}&id=${id}`}>
-      <TaskLi draggable>
-        <span>{title}</span>
-        {manager && <CircleIcon>{manager.slice(0, 1)}</CircleIcon>}
-      </TaskLi>
-    </Link>
+    <>
+      {dropId === id && dndDrag.id && dndDrag.id !== dndDrop.id && <EmptySpace />}
+      <Link to={`/?mode=edit&state=${state}&id=${id}`}>
+        <TaskLi draggable onDragStart={onDragStart} onDragEnter={onDragEnd} isActive={dropId === id}>
+          <span>{title}</span>
+          {manager && <CircleIcon>{manager.slice(0, 1)}</CircleIcon>}
+        </TaskLi>
+      </Link>
+    </>
   );
 };
-const TaskLi = styled.li`
+const TaskLi = styled.li<{ isActive: boolean }>`
   border-radius: 8px;
   padding: 12px;
   margin: 12px 4px;
   background-color: white;
   display: flex;
   flex-direction: column;
-  cursor: pointer;
-  user-select: none;
+  cursor: grab;
+  position: relative;
   font-weight: 500;
+`;
+const EmptySpace = styled.div`
+  border-radius: 8px;
+  padding: 20px 12px;
+  margin: 12px 4px;
+  background-color: rgba(192, 192, 192, 0.4);
+  content: '';
 `;
 export const CircleIcon = styled.div`
   border-radius: 50%;

--- a/src/components/taskList/TaskList.tsx
+++ b/src/components/taskList/TaskList.tsx
@@ -24,11 +24,8 @@ const TaskList = ({ title, list }: { title: string; list: ListContent[] }) => {
     },
   });
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
     const { drag, drop } = dndValue;
-    console.log(drag, drop);
-    if (e.currentTarget.tagName !== 'LI') return;
-
-    // const { drag, drop } = dndValue;
     if (drag.state === drop.state && drag.id === drop.id) {
       if (drag.state !== title) {
         fetcher.mutate({ drag, drop: { id: '', state: title } });

--- a/src/components/taskList/TaskList.tsx
+++ b/src/components/taskList/TaskList.tsx
@@ -26,6 +26,7 @@ const TaskList = ({ title, list }: { title: string; list: ListContent[] }) => {
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const { drag, drop } = dndValue;
+    console.log(drag, drop);
     if (drag.state === drop.state && drag.id === drop.id) {
       if (drag.state !== title) {
         fetcher.mutate({ drag, drop: { id: '', state: title } });

--- a/src/components/taskList/TaskTitleForm.tsx
+++ b/src/components/taskList/TaskTitleForm.tsx
@@ -45,6 +45,7 @@ const TitleForm = styled.form`
   display: inline-block;
   width: 90%;
   box-sizing: border-box;
+  -webkit-user-drag: none;
 `;
 
 const TitleInput = styled.input<{ size: number }>`

--- a/src/graphql/lists.ts
+++ b/src/graphql/lists.ts
@@ -65,3 +65,14 @@ export const DELETE_ITEM = gql`
     id
   }
 `;
+export const PUT_DND = gql`
+  mutation PUT_DND {
+    state
+    list {
+      id
+      order
+      title
+      manager
+    }
+  }
+`;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -127,6 +127,7 @@ export const handlers = [
   graphql.mutation(PUT_DND, (req, res, ctx) => {
     const data = req.variables;
     const { drag, drop } = data as Dnd;
+
     const dragStateIdx = lists.findIndex(({ state: title }) => title === drag.state);
     const dropStateIdx = lists.findIndex(({ state: title }) => title === drop.state);
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -132,9 +132,9 @@ export const handlers = [
 
     if (!(dragStateIdx > -1 && dropStateIdx > -1)) return res(ctx.status(404));
     const dragIdIdx = lists[dragStateIdx].list.findIndex(({ id: idx }) => drag.id === idx);
-    console.log(dragIdIdx);
+
     const dropIdIdx = lists[dropStateIdx].list.findIndex(({ id: idx }) => drop.id === idx);
-    console.log(dragIdIdx, dropIdIdx);
+
     const dragItem = lists[dragStateIdx].list.splice(dragIdIdx, 1);
     if (dropIdIdx === -1) {
       lists[dropStateIdx].list.push(dragItem[0]);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
-import { StateChange, List } from '../types/lists';
-import { atom, selector } from 'recoil';
+import { StateChange, List, Dnd, DndContent } from '../types/lists';
+import { atom, selector, selectorFamily } from 'recoil';
 
 export const listAtom = atom<List[]>({
   key: 'listAtom',
@@ -33,4 +33,29 @@ export const listNameSelector = selector<string[] | StateChange>({
       }),
     );
   },
+});
+
+export const dndAtom = atom<Dnd>({
+  key: 'dndAtom',
+  default: {
+    drag: { id: '', state: '' },
+    drop: { id: '', state: '' },
+  },
+});
+
+export const dndSelector = selectorFamily<DndContent | Dnd, string>({
+  key: 'dndSelector',
+  get:
+    (param: string) =>
+    ({ get }) => {
+      const data = get(dndAtom);
+      return data[param];
+    },
+  set:
+    (param: string) =>
+    ({ get, set }, value) => {
+      const data = get(dndAtom);
+      const newData = { ...data, [param]: value } as Dnd;
+      set(dndAtom, newData);
+    },
 });

--- a/src/types/lists.ts
+++ b/src/types/lists.ts
@@ -32,3 +32,13 @@ export interface FamilyListValue {
   state: string;
   item: ListContent;
 }
+export interface DndContent {
+  [index: string]: string;
+  id: string;
+  state: string;
+}
+export interface Dnd {
+  [index: string]: DndContent;
+  drag: DndContent;
+  drop: DndContent;
+}


### PR DESCRIPTION
- [x] Drag&Drop 이벤트 
**Drag: drag 하려는 요소에 
dragStart, dragEnd, dragEnter 이벤트** 
```
  const dropId = dndDrop.id === '' ? '-1' : dndDrop.id;
  const onDragStart = () => {
    setDndDrag({ id, state });
  };
  const onDragEnd = () => {
    if (dndDrag.id === id) {
      setDndDrop({ ...dndDrag });
    }
  };
  const onDragEnter = () => {
    if (dndDrag.id !== id) {
      setDndDrop({ id, state });
    } else {
      setDndDrop({ ...dndDrag });
    }
  };
------

   <TaskLi draggable onDragStart={onDragStart} onDragEnd={onDragEnd} onDragEnter={onDragEnter}>
          <span>{title}</span>
          {manager && <CircleIcon>{manager.slice(0, 1)}</CircleIcon>}
        </TaskLi>


```

   - dragStart - 드래그가 시작될 때/ 해당 컴포넌트의 id값과 state값을 저장
   - dragEnter - 드래그 중에 해당 요소에 진입할 때/ 진입했을 시 id값과 드래그가 시작된 요소의 id값이 다를 때 만  해당 컴포넌트의 id값과 state값을 저장,
   - dragEnd - 드래그가 종료될 때(위치 상관없음)/ 드롭이 되지 않는 위치에 놓아졌을 때 drag와 drop의 id/state를 동일화시켜서 통신이 안가게끔 함.  
  
  
  
**Drop:드롭할 요소에 dragOver,drop 이벤트**
     
```
  const onDrop = (e: DragEvent<HTMLDivElement>) => {
    e.preventDefault();
    const { drag, drop } = dndValue;
    console.log(drag, drop);
    if (drag.state === drop.state && drag.id === drop.id) {
      if (drag.state !== title) {
        fetcher.mutate({ drag, drop: { id: '', state: title } });
      }
    } else if (drop.state !== title) {
      fetcher.mutate({ drag, drop: { id: '', state: title } });
    } else {
      fetcher.mutate(dndValue);
    }
  };
  ```

- [x] msw handler 설정
- [x] Dnd시 활성 영역에 예상 위치 보여주는 거 삽입하기 

추가 문제:
예를 들면 todo 에서 in_progress로 이동할 때 잘 되지만, todo에서 todo로 이동할 때나 맨 아래로 옮기고 싶을 때   
나오지 않거나, 이상한 위치에 생성됨을 인지  ,추후 수정
```  {dndDrop.id === id && dndDrag.id !== dndDrop.id && <EmptySpace />}```